### PR TITLE
Enable stopping/starting of container without manual intervention.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ MAINTAINER psteger.com <ps@psteger.com>
 RUN apt-get update && apt-get install -y wget mariadb-server && apt-get clean && rm -rf /var/lib/apt/lists/*
 WORKDIR /root
 COPY setup.sh /root
+COPY start.sh /root
 RUN chmod +x setup.sh
+RUN chmod +x start.sh
 EXPOSE 80
-ENTRYPOINT /root/setup.sh && /bin/bash
+ENTRYPOINT /root/setup.sh && /root/start.sh && /bin/bash

--- a/setup.sh
+++ b/setup.sh
@@ -77,7 +77,6 @@ else
         echo "Moving DB Folder..."
         mv /var/lib/mysql /shared && mv /shared/mysql /shared/db && ln -s /shared/db /var/lib/mysql
     fi
-    service mysql start
 
     echo "Setup complete. Login credentials saved in /shared/logs"
     cp /opt/seafile/aio_seafile-server.log /shared/logs/setup.log
@@ -86,6 +85,4 @@ else
     chown -R root:root /shared/logs
     chown -R root:root /shared/seafile
     chown -R root:root /opt/seafile
-    /opt/seafile/seafile-server-latest/seafile.sh start
-    /opt/seafile/seafile-server-latest/seahub.sh start
 fi

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+echo "Starting mysql and seafile and seahub..."
+service mysql start
+/opt/seafile/seafile-server-latest/seafile.sh start
+/opt/seafile/seafile-server-latest/seahub.sh start 80
+echo "Restarting nginx..."
+service nginx restart


### PR DESCRIPTION
The Seafile server is not started when the container is stopped and started. This means you need to enter the container manually and execute a few commands.

I have resolved this issue by delegating the startup process to `start.sh` and added this script to the Docker execution command.

Please also test this yourself before merging.